### PR TITLE
Add intranet page with copilot

### DIFF
--- a/backend/chainlit/translations/en-US.json
+++ b/backend/chainlit/translations/en-US.json
@@ -212,6 +212,7 @@
     "best-practice": "Best Practice"
   },
   "intranet": {
-    "placeholder": "Have a chat to get started"
+    "placeholder": "Have a chat to get started",
+    "searchPlaceholder": "Search intranet..."
   }
 }

--- a/backend/chainlit/translations/en-US.json
+++ b/backend/chainlit/translations/en-US.json
@@ -210,5 +210,8 @@
     "security": "Security",
     "beta": "Beta",
     "best-practice": "Best Practice"
+  },
+  "intranet": {
+    "placeholder": "Have a chat to get started"
   }
 }

--- a/frontend/public/elements/Article.jsx
+++ b/frontend/public/elements/Article.jsx
@@ -1,0 +1,12 @@
+export default function Article(props) {
+  return (
+    <div className="max-w-2xl p-4">
+      <h1 className="text-3xl font-bold mb-4">{props.title}</h1>
+      {(props.paragraphs || []).map((p, i) => (
+        <p key={i} className="mb-2">
+          {p}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export default function Calendar() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const weeks: (number | null)[][] = [];
+  let day = 1 - firstDay;
+  for (let i = 0; i < 6; i++) {
+    const week: (number | null)[] = [];
+    for (let j = 0; j < 7; j++) {
+      if (day < 1 || day > daysInMonth) {
+        week.push(null);
+      } else {
+        week.push(day);
+      }
+      day++;
+    }
+    weeks.push(week);
+  }
+
+  const monthLabel = now.toLocaleString('default', { month: 'long', year: 'numeric' });
+  const days = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+  return (
+    <div className="border rounded-md p-2 text-sm">
+      <div className="text-center font-bold mb-2">{monthLabel}</div>
+      <div className="grid grid-cols-7 gap-1">
+        {days.map((d) => (
+          <div key={d} className="text-center font-semibold">
+            {d}
+          </div>
+        ))}
+        {weeks.flat().map((d, i) => (
+          <div key={i} className="text-center h-6">
+            {d || ''}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Intranet.tsx
+++ b/frontend/src/pages/Intranet.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react';
 
 import { Logo } from '@/components/Logo';
 import { useTranslation } from '@/components/i18n/Translator';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import Calendar from '@/components/Calendar';
 
 export default function Intranet() {
   const [Component, setComponent] = useState<React.ComponentType<any>>();
@@ -42,12 +45,52 @@ export default function Intranet() {
 
   const Element = Component;
 
+  const latestArticles = [
+    'Welcome to the intranet',
+    'How to request PTO',
+    'Quarterly results',
+    'New office policy',
+    'Benefits overview'
+  ];
+
+  const ArticleBubble = ({ title }: { title: string }) => (
+    <Button variant="outline" className="w-fit rounded-3xl" size="sm">
+      <p className="text-sm text-muted-foreground truncate">{title}</p>
+    </Button>
+  );
+
   return (
-    <div className="h-screen w-screen flex items-center justify-center relative p-4">
-      {Element ? <Element {...props} /> : <Logo className="w-52" />}
-      <p className="fixed bottom-24 right-8 text-sm text-muted-foreground">
-        {t('intranet.placeholder')}
-      </p>
+    <div className="flex flex-col h-screen w-screen">
+      <header className="flex items-center justify-between p-4 border-b">
+        <Logo className="h-10" />
+        <Input
+          type="search"
+          placeholder={t('intranet.searchPlaceholder')}
+          className="max-w-xs"
+        />
+      </header>
+      <div className="p-4 flex flex-wrap gap-2 justify-center border-b">
+        {latestArticles.slice(0, 5).map((a, i) => (
+          <ArticleBubble key={i} title={a} />
+        ))}
+      </div>
+      <div className="flex flex-grow overflow-hidden">
+        <div className="flex-1 flex flex-col items-center overflow-auto p-4">
+          {Element ? (
+            <Element {...props} />
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-2 mt-10">
+              <Logo className="w-52" />
+              <p className="text-sm text-muted-foreground">
+                {t('intranet.placeholder')}
+              </p>
+            </div>
+          )}
+        </div>
+        <div className="w-80 p-4 border-l overflow-auto hidden md:block">
+          <Calendar />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Intranet.tsx
+++ b/frontend/src/pages/Intranet.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { Logo } from '@/components/Logo';
+
+interface Article {
+  title: string;
+  paragraphs: string[];
+}
+
+export default function Intranet() {
+  const [article, setArticle] = useState<Article | null>(null);
+
+  useEffect(() => {
+    // Mount copilot widget when available
+    if (window.mountChainlitWidget) {
+      window.mountChainlitWidget({ chainlitServer: window.location.origin });
+    }
+    const handler = (e: any) => {
+      const { name, args, callback } = e.detail;
+      if (name === 'render_article') {
+        setArticle({
+          title: args.title,
+          paragraphs: args.paragraphs || [],
+        });
+        if (callback) callback({ success: true });
+      }
+    };
+    window.addEventListener('chainlit-call-fn', handler);
+    return () => {
+      window.removeEventListener('chainlit-call-fn', handler);
+      if (window.unmountChainlitWidget) {
+        window.unmountChainlitWidget();
+      }
+    };
+  }, []);
+
+  return (
+    <div className="h-screen w-screen flex items-center justify-center relative">
+      {article ? (
+        <div className="max-w-2xl p-4">
+          <h1 className="text-3xl font-bold mb-4">{article.title}</h1>
+          {article.paragraphs.map((p, i) => (
+            <p key={i} className="mb-2">
+              {p}
+            </p>
+          ))}
+        </div>
+      ) : (
+        <Logo className="w-52" />
+      )}
+      <p className="fixed bottom-24 right-8 text-sm text-muted-foreground">
+        Have a chat to get started
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Intranet.tsx
+++ b/frontend/src/pages/Intranet.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Logo } from '@/components/Logo';
-import { useTranslation } from '@/components/i18n';
+import { useTranslation } from '@/components/i18n/Translator';
 
 export default function Intranet() {
   const [Component, setComponent] = useState<React.ComponentType<any>>();

--- a/frontend/src/pages/Intranet.tsx
+++ b/frontend/src/pages/Intranet.tsx
@@ -1,54 +1,52 @@
 import { useEffect, useState } from 'react';
-import { Logo } from '@/components/Logo';
 
-interface Article {
-  title: string;
-  paragraphs: string[];
-}
+import { Logo } from '@/components/Logo';
+import { useTranslation } from '@/components/i18n';
 
 export default function Intranet() {
-  const [article, setArticle] = useState<Article | null>(null);
+  const [Component, setComponent] = useState<React.ComponentType<any>>();
+  const [props, setProps] = useState<Record<string, unknown>>({});
+  const { t } = useTranslation();
 
   useEffect(() => {
-    // Mount copilot widget when available
-    if (window.mountChainlitWidget) {
-      window.mountChainlitWidget({ chainlitServer: window.location.origin });
+    const w = window as any;
+    if (w.mountChainlitWidget) {
+      w.mountChainlitWidget({ chainlitServer: window.location.origin });
     }
-    const handler = (e: any) => {
+
+    const handler = async (e: any) => {
       const { name, args, callback } = e.detail;
-      if (name === 'render_article') {
-        setArticle({
-          title: args.title,
-          paragraphs: args.paragraphs || [],
-        });
-        if (callback) callback({ success: true });
+      if (name === 'render_element' && args?.component) {
+        try {
+          const mod = await import(
+            /* @vite-ignore */ `/elements/${args.component}.jsx`
+          );
+          setComponent(() => mod.default);
+          setProps(args.props || {});
+          callback?.({ success: true });
+        } catch (err) {
+          console.error(err);
+          callback?.({ success: false, error: String(err) });
+        }
       }
     };
+
     window.addEventListener('chainlit-call-fn', handler);
     return () => {
       window.removeEventListener('chainlit-call-fn', handler);
-      if (window.unmountChainlitWidget) {
-        window.unmountChainlitWidget();
+      if (w.unmountChainlitWidget) {
+        w.unmountChainlitWidget();
       }
     };
   }, []);
 
+  const Element = Component;
+
   return (
-    <div className="h-screen w-screen flex items-center justify-center relative">
-      {article ? (
-        <div className="max-w-2xl p-4">
-          <h1 className="text-3xl font-bold mb-4">{article.title}</h1>
-          {article.paragraphs.map((p, i) => (
-            <p key={i} className="mb-2">
-              {p}
-            </p>
-          ))}
-        </div>
-      ) : (
-        <Logo className="w-52" />
-      )}
+    <div className="h-screen w-screen flex items-center justify-center relative p-4">
+      {Element ? <Element {...props} /> : <Logo className="w-52" />}
       <p className="fixed bottom-24 right-8 text-sm text-muted-foreground">
-        Have a chat to get started
+        {t('intranet.placeholder')}
       </p>
     </div>
   );

--- a/frontend/src/pages/Intranet.tsx
+++ b/frontend/src/pages/Intranet.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { Logo } from '@/components/Logo';
 import { useTranslation } from '@/components/i18n/Translator';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import Calendar from '@/components/Calendar';
+import Page from 'pages/Page';
 
 export default function Intranet() {
   const [Component, setComponent] = useState<React.ComponentType<any>>();
@@ -45,52 +43,18 @@ export default function Intranet() {
 
   const Element = Component;
 
-  const latestArticles = [
-    'Welcome to the intranet',
-    'How to request PTO',
-    'Quarterly results',
-    'New office policy',
-    'Benefits overview'
-  ];
-
-  const ArticleBubble = ({ title }: { title: string }) => (
-    <Button variant="outline" className="w-fit rounded-3xl" size="sm">
-      <p className="text-sm text-muted-foreground truncate">{title}</p>
-    </Button>
-  );
-
   return (
-    <div className="flex flex-col h-screen w-screen">
-      <header className="flex items-center justify-between p-4 border-b">
-        <Logo className="h-10" />
-        <Input
-          type="search"
-          placeholder={t('intranet.searchPlaceholder')}
-          className="max-w-xs"
-        />
-      </header>
-      <div className="p-4 flex flex-wrap gap-2 justify-center border-b">
-        {latestArticles.slice(0, 5).map((a, i) => (
-          <ArticleBubble key={i} title={a} />
-        ))}
+    <Page>
+      <div className="flex flex-col h-full w-full items-center justify-center overflow-auto p-4">
+        {Element ? (
+          <Element {...props} />
+        ) : (
+          <div className="flex flex-col items-center gap-2 mt-10">
+            <Logo className="w-52" />
+            <p className="text-sm text-muted-foreground">{t('intranet.placeholder')}</p>
+          </div>
+        )}
       </div>
-      <div className="flex flex-grow overflow-hidden">
-        <div className="flex-1 flex flex-col items-center overflow-auto p-4">
-          {Element ? (
-            <Element {...props} />
-          ) : (
-            <div className="flex flex-col items-center justify-center gap-2 mt-10">
-              <Logo className="w-52" />
-              <p className="text-sm text-muted-foreground">
-                {t('intranet.placeholder')}
-              </p>
-            </div>
-          )}
-        </div>
-        <div className="w-80 p-4 border-l overflow-auto hidden md:block">
-          <Calendar />
-        </div>
-      </div>
-    </div>
+    </Page>
   );
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@ import AuthCallback from 'pages/AuthCallback';
 import Element from 'pages/Element';
 import Env from 'pages/Env';
 import Home from 'pages/Home';
+import Intranet from 'pages/Intranet';
 import Login from 'pages/Login';
 import Thread from 'pages/Thread';
 
@@ -13,6 +14,10 @@ export const router = createBrowserRouter(
     {
       path: '/',
       element: <Home />
+    },
+    {
+      path: '/intranet',
+      element: <Intranet />
     },
     {
       path: '/env',


### PR DESCRIPTION
## Summary
- create `Intranet` page that mounts the Copilot widget
- expose `render_article` via `chainlit-call-fn` event
- route `/intranet` to the new page

## Testing
- `pnpm --filter @chainlit/app lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68557ac9a3788331bb27b6b9facf5a4a